### PR TITLE
fix parse origin URL for Internet Explorer

### DIFF
--- a/src/LightBox.js
+++ b/src/LightBox.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import PaymentPageFrame from './PaymentPageFrame'
 import {
-  filterProps, toUrlParams, parseUrl,
+  filterProps, toUrlParams, getBaseUrl,
   lockScrolling,
   releaseLock
 } from './utils'
@@ -31,7 +31,7 @@ export default class LightBox extends Component {
 
     const urlParams = filterProps(this.props, rejectProps)
     this.url = buildUrl(urlParams, this.props.production)
-    this.origin = parseUrl(this.url).origin
+    this.origin = getBaseUrl(this.url)
 
     this.state = { visible: true}
   }

--- a/src/PaymentPage.js
+++ b/src/PaymentPage.js
@@ -10,7 +10,6 @@ const PaymentPage = props => {
     id='datatransPaymentFrame'
     name='datatransPaymentFrame'
     frameBorder={0}
-    allowTransparency={true}
   />
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,15 +14,16 @@ export const set = (target, key, value) => {
   target[key] = value
   return target
 }
+
 export const toUrlParams = props => Object.keys(props)
 .map(key => `${key}=${props[key]}`)
 .join('&')
 
-
-export const parseUrl = url => {
-  const a = document.createElement('a')
-  a.href = url
-  return a
+export const getBaseUrl = url => {
+  const pathArray = url.split('/')
+  const protocol = pathArray[0]
+  const host = pathArray[2]
+  return protocol + '//' + host
 }
 
 export const lockScrolling = () => {


### PR DESCRIPTION
This pull requests covers two issues:

* The internet `parseUrl` utility method did not work on the Internet Explorer. The result was that the message events from within the iframe never reached the application.
* The iframe attribute `allowTransparency` is [not allowed anymore in HTML5](http://help.simplytestable.com/errors/html-validation/the-x-attribute-on-the-y-element-is-obsolete-use-css-instead/the-allowtransparency-attribute-on-the-iframe-element-is-obsolete-use-css-instead/). => Removed it.